### PR TITLE
Feature: Create dividers along Y axis

### DIFF
--- a/FreeCAD-Macros/in3dca/StorageBox.py
+++ b/FreeCAD-Macros/in3dca/StorageBox.py
@@ -132,7 +132,8 @@ class StorageBox:
         # Generate the front face
         self.closed_front = True
         # Number of areas within the box
-        self.divisions = 0
+        self.divisions_x = 0
+        self.divisions_y = 0
         self.divider_width = 1.2
         self.floor_thickness = self.MIN_FLOOR
         self.grip_depth = 0.0
@@ -237,26 +238,47 @@ class StorageBox:
         return corner
 
     def dividers(self):
-        if self.divisions <= 1:
+        if self.divisions_x <= 1 and self.divisions_y <= 1:
             return []
-        offset = self.divider_width / 2.0
-        # Create the divider profile in the XZ plane, clockwise from top left
-        # when looking toward +Y
-        points = [
-            h.xyz(-offset, self.WALL_THICKNESS, self.size_z - self.INSIDE_RIM_BOTTOM),
-            h.xyz(offset, self.WALL_THICKNESS, self.size_z - self.INSIDE_RIM_BOTTOM),
-            h.xyz(offset, self.WALL_THICKNESS, self.floor_thickness + 1.0),
-            h.xyz(offset + 1.0, self.WALL_THICKNESS, self.floor_thickness),
-            h.xyz(-offset - 1.0, self.WALL_THICKNESS, self.floor_thickness),
-            h.xyz(-offset, self.WALL_THICKNESS, self.floor_thickness + 1.0),
-        ]
-        profile = h.poly_to_face(points, 1)
-        divider = profile.extrude(h.xyz(y=self.size_y - 2 * self.WALL_THICKNESS))
+
         dividers = []
-        spacing = self.size_x / self.divisions
-        for i in range(1, self.divisions):
-            divider.Placement = Placement(h.xyz(spacing * i), Rotation())
-            dividers.append(copy.copy(divider))
+        offset = self.divider_width / 2.0
+        # Create the x divider profile in the XZ plane, clockwise from top left
+        # when looking toward +Y
+        if self.divisions_x > 1:
+            points = [
+                h.xyz(-offset, self.WALL_THICKNESS, self.size_z - self.INSIDE_RIM_BOTTOM),
+                h.xyz(offset, self.WALL_THICKNESS, self.size_z - self.INSIDE_RIM_BOTTOM),
+                h.xyz(offset, self.WALL_THICKNESS, self.floor_thickness + 1.0),
+                h.xyz(offset + 1.0, self.WALL_THICKNESS, self.floor_thickness),
+                h.xyz(-offset - 1.0, self.WALL_THICKNESS, self.floor_thickness),
+                h.xyz(-offset, self.WALL_THICKNESS, self.floor_thickness + 1.0),
+            ]
+            profile = h.poly_to_face(points, 1)
+            divider = profile.extrude(h.xyz(y=self.size_y - 2 * self.WALL_THICKNESS))
+            spacing = self.size_x / self.divisions_x
+            for i in range(1, self.divisions_x):
+                divider.Placement = Placement(h.xyz(spacing * i), Rotation())
+                dividers.append(copy.copy(divider))
+
+        # Create the y divider profile in the YZ plane, clockwise from top left
+        # when looking toward +X
+        if self.divisions_y > 1:
+            points = [
+                h.xyz(self.WALL_THICKNESS, -offset, self.size_z - self.INSIDE_RIM_BOTTOM),
+                h.xyz(self.WALL_THICKNESS, offset, self.size_z - self.INSIDE_RIM_BOTTOM),
+                h.xyz(self.WALL_THICKNESS, offset, self.floor_thickness + 1.0),
+                h.xyz(self.WALL_THICKNESS, offset + 1.0, self.floor_thickness),
+                h.xyz(self.WALL_THICKNESS, -offset - 1.0, self.floor_thickness),
+                h.xyz(self.WALL_THICKNESS, -offset, self.floor_thickness + 1.0),
+            ]
+            profile = h.poly_to_face(points, 1)
+            divider = profile.extrude(h.xyz(x=self.size_x - 2 * self.WALL_THICKNESS))
+            spacing = self.size_y / self.divisions_y
+            for i in range(1, self.divisions_y):
+                divider.Placement = Placement(h.xyz(0, spacing * i), Rotation())
+                dividers.append(copy.copy(divider))
+
         return dividers
 
     def floor(self, depth, width):
@@ -610,7 +632,8 @@ class StorageBox:
         # Generate the front face
         self.closed_front = True
         # Number of areas within the box
-        self.divisions = 0
+        self.divisions_x = 0
+        self.divisions_y = 0
         self.divider_width = 1.2
         self.floor_thickness = self.MIN_FLOOR
         self.grip_depth = 0.0
@@ -681,21 +704,24 @@ class StorageBox:
         shift += incr
 
         self.reset()
-        self.divisions = 2
+        self.divisions_x = 2
+        self.divisions_y = 1
         b1x1x1d2 = self.make()
         b1x1x1d2.Placement = Placement(origin.add(h.xyz(shift)), Rotation())
         Part.show(b1x1x1d2, 'b1x1x1d2')
         shift += incr
 
         self.reset()
-        self.divisions = 3
+        self.divisions_x = 3
+        self.divisions_y = 1
         b1x1x3d3 = self.make(1, 1, 3)
         b1x1x3d3.Placement = Placement(origin.add(h.xyz(shift)), Rotation())
         Part.show(b1x1x3d3, 'b1x1x1d3')
         shift += incr
 
         self.reset()
-        self.divisions = 3
+        self.divisions_x = 3
+        self.divisions_y = 1
         self.grip_depth = 15
         b1x1x3d3_grip = self.make(1, 1, 3)
         b1x1x3d3_grip.Placement = Placement(origin.add(h.xyz(shift)), Rotation())
@@ -719,7 +745,8 @@ class StorageBox:
         shift += incr
 
         self.reset()
-        self.divisions = 2
+        self.divisions_x = 2
+        self.divisions_y = 1
         b1x2x1p2 = self.make(1, 2)
         b1x2x1p2.Placement = Placement(origin.add(h.xyz(shift)), Rotation())
         Part.show(b1x2x1p2, 'b1x2x1p2')
@@ -766,8 +793,10 @@ class StorageBox:
             self.as_components = value
         elif name == 'closed_front':
             self.closed_front = value
-        elif name == 'divisions':
-            self.divisions = value
+        elif name == 'divisions_x':
+            self.divisions_x = value
+        elif name == 'divisions_y':
+            self.divisions_y = value
         elif name == 'grip_depth':
             self.grip_depth = value
         # Set to make magnet holes

--- a/FreeCAD-Macros/in3dca_storage.FCMacro
+++ b/FreeCAD-Macros/in3dca_storage.FCMacro
@@ -59,7 +59,8 @@ except AttributeError:
 try:
     _fromUtf8 = QtCore.QString.fromUtf8
 except AttributeError:
-    _fromUtf8 = lambda s: s
+    def _fromUtf8(s):
+        return s
 
 
 class In3dGridUi(QtGui.QWidget):
@@ -97,11 +98,16 @@ class In3dGridUi(QtGui.QWidget):
         self.box_z.setMaxLength(3)
         self.box_z.setText("1")
         form.addRow("Box Height (z, 10mm units)", self.box_z)
-        self.box_divs = QtGui.QLineEdit()
-        self.box_divs.setValidator(plus_int)
-        self.box_divs.setMaxLength(3)
-        self.box_divs.setText("1")
-        form.addRow("Number of divisions", self.box_divs)
+        self.box_divs_x = QtGui.QLineEdit()
+        self.box_divs_x.setValidator(plus_int)
+        self.box_divs_x.setMaxLength(3)
+        self.box_divs_x.setText("1")
+        form.addRow("Number of divisions along the X axis", self.box_divs_x)
+        self.box_divs_y = QtGui.QLineEdit()
+        self.box_divs_y.setValidator(plus_int)
+        self.box_divs_y.setMaxLength(3)
+        self.box_divs_y.setText("1")
+        form.addRow("Number of divisions along the Y axis", self.box_divs_y)
         self.box_open_front = QtGui.QCheckBox("Leave front of box open")
         self.box_open_front.setChecked(False)
         form.addRow(self.box_open_front)
@@ -241,9 +247,12 @@ class In3dGridUi(QtGui.QWidget):
         box.as_components = self.opt_as_objects.isChecked()
         box.closed_front = not self.box_open_front.isChecked()
         depth = int(self.box_grip_depth.text())
-        box.divisions = int(self.box_divs.text())
-        if box.divisions < 1:
-            box.divisions = 1
+        box.divisions_x = int(self.box_divs_x.text())
+        box.divisions_y = int(self.box_divs_y.text())
+        if box.divisions_x < 1:
+            box.divisions_x = 1
+        if box.divisions_y < 1:
+            box.divisions_y = 1
         if self.box_grip.isChecked() and depth > 0:
             box.grip_depth = depth
         if self.opt_magnets_none.isChecked():


### PR DESCRIPTION
- Previously you only could make divisions along X axis, in case you wanted along Y axis an alternative was to swap the width and depth dimensions.
- But still is you wanted a grid you needed to manually complete it using the Sketcher WB.
- Now you can create dividers along X axis, Y axis or both.
![screenshot1695945811](https://github.com/instancezero/in3dca-freegrid/assets/53124818/e8d3af58-a99d-4b0a-9f8e-493e62e532db)

