### PR TITLE
Feature: Allow to type the height in mm.

### DIFF
--- a/FreeCAD-Macros/in3dca/StorageBox.py
+++ b/FreeCAD-Macros/in3dca/StorageBox.py
@@ -509,7 +509,7 @@ class StorageBox:
         holder = holder.cut(h.disk(mag_radius + 0.1, 2.2))
         return holder
 
-    def make(self, depth=1, width=1, height=1, floor_thickness=None):
+    def make(self, depth=1, width=1, height=1.0, floor_thickness=None):
         if floor_thickness is not None:
             self.floor_thickness = floor_thickness
         if self.floor_thickness < self.MIN_FLOOR:

--- a/FreeCAD-Macros/in3dca_storage.FCMacro
+++ b/FreeCAD-Macros/in3dca_storage.FCMacro
@@ -93,10 +93,9 @@ class In3dGridUi(QtGui.QWidget):
         self.box_y.setText("1")
         form.addRow("Box Depth (y, 50mm units)", self.box_y)
         self.box_z = QtGui.QLineEdit()
-        self.box_z.setValidator(plus_int)
-        self.box_z.setMaxLength(3)
+        self.box_z.setMaxLength(5)
         self.box_z.setText("1")
-        form.addRow("Box Height (z, 10mm units)", self.box_z)
+        form.addRow("Box Height (z, 10mm units or \ndimension with mm sufix)", self.box_z)
         self.box_divs = QtGui.QLineEdit()
         self.box_divs.setValidator(plus_int)
         self.box_divs.setMaxLength(3)
@@ -257,13 +256,27 @@ class In3dGridUi(QtGui.QWidget):
 
         x = int(self.box_x.text())
         y = int(self.box_y.text())
-        z = int(self.box_z.text())
+        z_text = self.box_z.text()
+        if "mm" in z_text:
+            zz = z_text.split('mm')
+            z = int("".join(zz))
+        else:
+            z = int(self.box_z.text())
+
         if x > 0 and y > 0 and z >= 0:
             self.message.setText("Generating...")
             self.message.repaint()
-            size = str(x) + "x" + str(y) + "x" + str(z)
-            Part.show(box.make(x, y, z), "In3D_" + size + "_box")
-            msg = "Created " + str(x) + "x" + str(y) + "x" + str(z) + " box"
+            if "mm" in z_text:
+                z_ = z / 10.0 # unit_height
+                alfa = 10
+                s_mm = "mm"
+            else:
+                z_ = z
+                alfa = 1
+                s_mm = ""
+            size = str(x) + "x" + str(y) + "x" + str(int(alfa*z_)) + s_mm
+            Part.show(box.make(x, y, z_), "In3D_" + size + "_box")
+            msg = "Created " + str(x) + "x" + str(y) + "x" + str(int(alfa*z_)) + s_mm + " box"
             if box.as_components:
                 msg += " as components"
             msg += "."


### PR DESCRIPTION
Right now the height is entered as multiple of the `unit_height`, this change allows the user to insert height in mm, example: 15mm.

Now both methods are valid, I took the idea of @johnsonm.

- Enter `5` and you get 5 units in height = 50mm
- Enter `50mm` and you get 50mm height

![screenshot1695951695](https://github.com/instancezero/in3dca-freegrid/assets/53124818/cc0ec4a6-5cdb-4f7b-a0e8-3a5951a10973)

Closes #2 