### PR TITLE
Bugfix: Remove dependency on copy.copy()

### DIFF
--- a/FreeCAD-Macros/in3dca/StorageBox.py
+++ b/FreeCAD-Macros/in3dca/StorageBox.py
@@ -36,9 +36,7 @@ __Requires__ = ''
 __Communication__ = ''
 __Files__ = ''
 
-import copy
 import DraftVecUtils
-import FreeCAD
 from FreeCAD import Placement, Rotation
 from in3dca import h
 import math
@@ -256,7 +254,7 @@ class StorageBox:
         spacing = self.size_x / self.divisions
         for i in range(1, self.divisions):
             divider.Placement = Placement(h.xyz(spacing * i), Rotation())
-            dividers.append(copy.copy(divider))
+            dividers.append(divider.copy())
         return dividers
 
     def floor(self, depth, width):


### PR DESCRIPTION
Previously the dividers copies were made with copy.copy() but due to some change it stoped working.

Now using the built-in copy() method is used for this task.

Since it's a bugfix, I'll merge it asap, probably a few hours open to see if some of you have a comment. @instancezero 

This bug is fixed thanks to Syres@FreeCADForum help:
- Forum post: https://forum.freecad.org/viewtopic.php?t=84293
- Reference commit: https://github.com/looooo/freecad.gears/commit/e6e6e9b7d4a57792a9b31502c22ccbbe62ccd91e
- Discussion about the change: https://github.com/FreeCAD/FreeCAD/issues/11514#issuecomment-1826413147

Tested on FC 0.21.2 & dev version
Fun fact: my question on the forum was answered faster than me making this bugfix PR :stuck_out_tongue_winking_eye: 

Fix #12