### PR TITLE
Make license entry a valid SPDX ID

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
   <maintainer email="">Alan Langford</maintainer>
   <maintainer email="">Michael K Johnson</maintainer>
   <maintainer email="hasecilu@tuta.io">hasecilu</maintainer>
-  <license file="LICENSE">AGPL-3.0 license</license>
+  <license file="LICENSE">AGPL-3.0-or-later</license>
   <pythonmin>3.6.0</pythonmin>
   <url type="repository" branch="main">https://github.com/instancezero/in3dca-freegrid</url>
   <url type="bugtracker">https://github.com/instancezero/in3dca-freegrid/issues</url>


### PR DESCRIPTION
The Addon manager expects the license to be a valid[ SPDX license ID](https://spdx.org/licenses/): here I propose "AGPL-3.0-or-later" but you might also have meant "AGPL-3.0-only".